### PR TITLE
Add script for selecting representative discrete disks

### DIFF
--- a/choose_relevant_disks.py
+++ b/choose_relevant_disks.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+"""Tool for choosing representative disks.
+
+Usage:
+  choose_relevant_disks.py -f | --file <in-filename> [--ct <ct>] [--nt <nt>] [--rt <rt>] [-o <out-filename>]
+
+Options:
+  -h --help                         Show this help.
+  -f --file                         File containing information about the disks in dsd format.
+  --ct <ct>                         Center threshold, maximal distance between the centers of two disks in the set of representative disks
+  --nt <nt>                         Normal threshold, maximal angle in degrees between the normals of two disks in the set of representative disks
+  --rt <rt>                         Radius threshold, maximal difference between the radiuses of two disks in the set of representative disks
+  -o --output-file <out-filename>   Dump representative disks (not too far, not too close, capturing the abrupt changes) to file in dsd format.
+
+"""
+
+import random
+import json
+import sys
+import visual as vs
+
+from docopt import docopt
+from digger import *
+from visual import *
+
+def load_disks_from_file(filename):
+    disks = []
+    if filename:
+        with open(filename, "r") as input_file:
+            for line in input_file:
+                numbers = line.split()
+                disk = Disk(np.array([float(numbers[0]), float(numbers[1]), float(numbers[2])]), np.array([float(numbers[3]), float(numbers[4]), float(numbers[5])]), float(numbers[6]))
+                disks.append(disk)
+        input_file.close()
+    return disks
+
+
+def choose_representative_disks(disks):
+    representative_disks = []
+    representative_disks.append(disks[0])
+    last = disks[0]
+    for disk in disks:
+        if (point_dist(last.center, disk.center) > center_threshold):
+            representative_disks.append(disk)
+            last = disk
+        if (angle_norm_vectors(last.normal, disk.normal) > normal_threshold):
+            representative_disks.append(disk)
+            last = disk
+        if (last.radius - disk.radius > radius_threshold):
+            representative_disks.append(disk)
+            last=disk
+    representative_disks.append(disks[-1])
+    return representative_disks
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+    filename = arguments['<in-filename>']
+    disks = []
+    disks = load_disks_from_file(filename)
+
+    center_threshold = float(arguments["--ct"] or 3.0)
+    normal_threshold = float(arguments["--nt"] or 20.0)
+    radius_threshold = float(arguments["--rt"] or 1.0)
+
+    disks = choose_representative_disks(disks)
+
+    output_path = arguments.get("--output-file")
+    if output_path:
+        with open(output_path, "w") as output_file:
+            for disk in disks:
+                line = "{} {} {} {} {} {} {}\n".format(disk.center[0],
+                    disk.center[1], disk.center[2], disk.normal[0], disk.normal[1],
+                    disk.normal[2], disk.radius)
+                output_file.write(line)
+

--- a/linalg.py
+++ b/linalg.py
@@ -13,6 +13,13 @@ def normalize(v):
        return v
     return v / norm
 
+def angle_norm_vectors(vector1, vector2):
+    cosx = np.dot(vector1, vector2)
+    if cosx < 1:
+        rad = np.arccos(cosx)
+        return rad*180/np.pi
+    return 0
+
 def null_space(A, eps=1e-15):
     u, s, vh = np.linalg.svd(A)
     null_space = np.compress(s <= eps, vh, axis=0)

--- a/show_disks.py
+++ b/show_disks.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+"""Molecule tunnel discretization tool.
+
+Usage:
+  show_disks.py -f | --file <in-filename> [-d <all-disks>] [-r <representative-disks>]
+
+Options:
+  -h --help                         Show this help.
+  -f --file                         File containing information about tunnel in molecule in PDB format.
+  -d                                File containing information about the discrete disks in the tunnel in dsd format, output of discretizer script.
+  -r                                File containing information about the representative disks in the tunnel in dsd format, output of choose_relevant_disks script.
+
+"""
+
+import random
+import json
+import sys
+import visual as vs
+
+from docopt import docopt
+from digger import *
+from choose_relevant_disks import *
+from visual import *
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__)
+    tunnel = Tunnel()
+    filename = arguments['<in-filename>']
+    tunnel.load_from_file(filename)
+    tunnel.t = tunnel.t[:]
+
+    all_disks = load_disks_from_file(arguments['<all-disks>'])
+    relevant_disks = load_disks_from_file(arguments['<representative-disks>'])
+
+    draw_ARG = True
+    # draw disks
+    if draw_ARG:
+        # set first sphere as a center of scene
+        cMin = tunnel.t[0].center.copy()
+        cMax = tunnel.t[0].center.copy()
+        for i, t in enumerate(tunnel.t):
+            #import pdb;pdb.set_trace()
+            for j in range(0, 3):
+                if cMin[j] > t.center[j]-t.radius:
+                    cMin[j] = t.center[j]-t.radius
+                if cMax[j] < t.center[j]+t.radius:
+                    cMax[j] = t.center[j]+t.radius
+        centScene = cMin + (cMax-cMin)/2
+
+        for i, s in enumerate(tunnel.t):
+            sVis = vs.sphere(pos = tuple(s.center - centScene),
+                                radius = s.radius, opacity=0.3)
+            # central line
+            if (i < len(tunnel.t)-1):
+                s2 = tunnel.t[i+1]
+                vVis = vs.arrow(pos=s.center - centScene,
+                                axis=(s2.center[0]-s.center[0],
+                                        s2.center[1]-s.center[1],
+                                        s2.center[2]-s.center[2]),
+                                color=(1,0,0), shaftwidth=0.3)
+        for i, disk in enumerate(all_disks[:]):
+            # if (i != 0):
+            #     print "Disk distance: {}".format(disk_dist(disks[i-1], disk))
+            vs.ring(pos=disk.center - centScene,
+                    axis=disk.normal,
+                    radius=disk.radius,
+                    thickness=0.01,
+                    color=(1,0,0))
+        for i, disk in enumerate(relevant_disks[:]):
+            # if (i != 0):
+            #     print "Disk distance: {}".format(disk_dist(disks[i-1], disk))
+            vs.ring(pos=disk.center - centScene,
+                    axis=disk.normal,
+                    radius=disk.radius,
+                    thickness=0.1,
+                    color=(0,1,0))
+            # if i % 2 == 1:
+            #     vVis = vs.arrow(pos=tuple(disk.center - centScene),
+            #                     axis=tuple(disk.normal * 0.25) ,
+            #                     color=(0,1,0), shaftwidth=0.5)
+
+


### PR DESCRIPTION
Hi,
I am working with Jiri Filipovic on CaverDock and he requested me to write a script that would take the output from your discretizer and select some disks that represent the path. They should be later used as reference structure for metadynamics simulations.

The commit includes three parts:
1. choose_relevant_disks.py includes the main algorithm. The representative disks are selected if one of three factors exceed the threshold:
- distance between centers
- angle between the normal vectors 
- difference between the radiuses.

2. show_disks.py visualizes the tunnel, all the disks (generated by discretizer) in thin red and selected disks (generated by choose_relevant_disks) in thick green.

3. linalg.py is slightly modified, I added the function to calculate the angle between the normal vectors in degrees for more intuitive setting of the threshold.

If you have any requirements before accepting the pull request, please let me know. I would be happy to adapt.

Regards,
Janka Pazurikova